### PR TITLE
5 revert traefik certs creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,3 @@
-Copyright (c) 2024 University of Illinois and others. All rights reserved.
-
-This program and the accompanying materials are made available under the
-terms of the Mozilla Public License v2.0 which accompanies this distribution,
-and is available at https://www.mozilla.org/en-US/MPL/2.0/
-
-<br>
-
-
 # Diamond Admin Dashboard
 
 ## Overview
@@ -75,3 +66,11 @@ Diamond Admin Dashboard is a comprehensive admin interface built with Next.js an
 ## Additional Information
 
 - Ensure all environment variables and configurations are set correctly in the `.env` file for both the backend and frontend services.
+
+<br>
+
+Copyright (c) 2024 University of Illinois and others. All rights reserved.
+
+This program and the accompanying materials are made available under the
+terms of the Mozilla Public License v2.0 which accompanies this distribution,
+and is available at https://www.mozilla.org/en-US/MPL/2.0/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,13 +38,6 @@ services:
 
   traefik:
     image: traefik:v3.1
-    entrypoint: >
-      /bin/sh -c "
-      mkdir -p /certs &&
-      touch /certs/acme.json &&
-      chmod 600 /certs/acme.json &&
-      /entrypoint.sh traefik
-      "
     command:
       - --log.level=DEBUG
       - --api
@@ -70,6 +63,7 @@ services:
       - "${TRAEFIK_HTTPS_PORT:-8443}:443"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock  # Mount the Docker daemon socket
+      - ./certs:/certs # Mount the certificates directory for acme.json file
     networks:
       - diamond-frontend-network
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,13 @@ services:
 
   traefik:
     image: traefik:v3.1
+    entrypoint: >
+      /bin/sh -c "
+      mkdir -p /certs &&
+      touch /certs/acme.json &&
+      chmod 600 /certs/acme.json &&
+      /entrypoint.sh traefik
+      "
     command:
       - --log.level=DEBUG
       - --api
@@ -63,7 +70,6 @@ services:
       - "${TRAEFIK_HTTPS_PORT:-8443}:443"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock  # Mount the Docker daemon socket
-      - ./certs:/certs # Mount the certificates directory for acme.json file
     networks:
       - diamond-frontend-network
     labels:


### PR DESCRIPTION
Reverted to original docker-compose.yaml file. This version is deployed in diamond.ncsa.illinois.edu